### PR TITLE
adds missing parameter for deployment file

### DIFF
--- a/deploy/relations-sink.yaml
+++ b/deploy/relations-sink.yaml
@@ -11,7 +11,7 @@ objects:
         strimzi.io/cluster: ${KAFKA_CONNECT_INSTANCE}
     spec:
       class: org.project_kessel.kafka.relations.sink.RelationsSinkConnector
-      tasksMax: ${MAX_TASKS}
+      tasksMax: ${{MAX_TASKS}}
       config:
         topics: "outbox.event.RelationReplicationEvent"
         relations-api.target-url: "kessel-relations-api:9000"
@@ -33,3 +33,6 @@ parameters:
 - name: CLIENT_SECRET
   required: true
   description: relations api auth client secret
+- name: MAX_TASKS
+  description: sets the max number of tasksMax
+  value: "1"


### PR DESCRIPTION
* Minor fixes to deployment manifest
  * For integer values, params must use 2 braces  (  `${{MAX_TASKS}}` ) to use non-string values
  * the `MAX_TASKS` parameter was missing from the definitions, which would cause it to never be configurable
  