### PR TITLE
Add retry mechanism for retriable failures and upsert mode for creates

### DIFF
--- a/src/main/java/org/project_kessel/kafka/relations/sink/RelationsSinkTask.java
+++ b/src/main/java/org/project_kessel/kafka/relations/sink/RelationsSinkTask.java
@@ -117,7 +117,7 @@ public class RelationsSinkTask extends SinkTask {
                     log.trace("Relations added");
                 }
             } catch (StatusRuntimeException e) {
-                /* Handle retryable exceptions here (using KafkaConnect's retry mechanism).
+                /* Handle retriable exceptions here (using KafkaConnect's retry mechanism).
                  *
                  * No retriable checked exceptions.
                  * Known retriable unchecked exceptions:


### PR DESCRIPTION
Fixes RHCLOUD-35728
Fixes RHCLOUD-35730

### Changes
- Make error handling in SinkTask explicit.
- Adopt kafka connect's retry mechanism for retriable failures.
- Change create tuples calls to upsert mode.

### Intended retry strategy
1. If the exception indicates a retriable failure, then throw `RetriableException`, indicating that the SinkTask has failed but can be retried. Kafka connector will try to process the replication event again.
2. Retry logic is configured at the connector level via the CR.
3. Successful tasks and successfully retried tasks increment the kafka offset.
4. Failed tasks fail fast (and hard) causing the sink connector to not process any more messages until the "blockage" is cleared.
5. Ordinary deletes and upsert creates in replication event should result in eventually consistent data even if a processing attempt is interrupted and retried.

### Tested (on local)
1. Default retry logic copes with spicedb going away and successfully completely relations-api call when spicedb comes back.
2. Default retry logic copes with relations-api going away and successfully completely relations-api call when it comes back and subsequently reconnects to spicedb.