### PR TITLE
makes the relations api address configurable

### DIFF
--- a/deploy/relations-sink-ephem.yaml
+++ b/deploy/relations-sink-ephem.yaml
@@ -75,7 +75,7 @@ objects:
       tasksMax: 1
       config:
         topics: "outbox.event.relations-replication-event"
-        relations-api.target-url: "kessel-relations-api:9000"
+        relations-api.target-url: ${RELATIONS_API_URL}
         relations-api.is-secure-clients: false
         relations-api.authn.mode: "disabled"
         relations-api.authn.client.issuer: ${secrets:relations-sink-config:relations-api.authn.client.issuer}
@@ -97,4 +97,8 @@ parameters:
     value: "0.1"
   - description: namespace for connector
     name: NAMESPACE
+    required: true
+  - description: Address of the relations api service
+    name: RELATIONS_API_URL
+    value: "kessel-relations-api:9000"
     required: true

--- a/deploy/relations-sink.yaml
+++ b/deploy/relations-sink.yaml
@@ -14,7 +14,7 @@ objects:
       tasksMax: ${{MAX_TASKS}}
       config:
         topics: "outbox.event.relations-replication-event"
-        relations-api.target-url: "kessel-relations-api:9000"
+        relations-api.target-url: ${RELATIONS_API_URL}
         relations-api.is-secure-clients: false
         relations-api.authn.mode: "disabled"
         relations-api.authn.client.issuer: ${CLIENT_ISSUER}
@@ -36,3 +36,7 @@ parameters:
 - name: MAX_TASKS
   description: sets the max number of tasksMax
   value: "1"
+- description: Address of the relations api service
+  name: RELATIONS_API_URL
+  value: "kessel-relations-api.kessel-stage.svc:9000"
+  required: true


### PR DESCRIPTION
* adds param for defining the relations api address so that it can be set in app interface, if it changes or a more explicit address is needed such as SVC_NAME.NAMESPACE.svc