### PR TITLE
RHCLOUD-37171: adds new param to deploy template

### DIFF
--- a/deploy/relations-sink.yaml
+++ b/deploy/relations-sink.yaml
@@ -16,7 +16,7 @@ objects:
         topics: "outbox.event.relations-replication-event"
         relations-api.target-url: ${RELATIONS_API_URL}
         relations-api.is-secure-clients: false
-        relations-api.authn.mode: "oidc-client-credentials"
+        relations-api.authn.mode: ${AUTHN_MODE}
         relations-api.authn.client.issuer: ${CLIENT_ISSUER}
         relations-api.authn.client.id: ${CLIENT_ID}
         relations-api.authn.client.secret: ${CLIENT_SECRET}
@@ -40,3 +40,7 @@ parameters:
   name: RELATIONS_API_URL
   value: "kessel-relations-api.kessel-stage.svc:9000"
   required: true
+- name: AUTHN_MODE
+  description: "Configures the authentication mode"
+  required: true
+  value: "oidc-client-credentials"


### PR DESCRIPTION
Small change to covert the authn setting to a parameter, this way we can deploy to FedRAMP initially with no auth requirements and not impact the deployments in commercial stage and prod. This will allow us to add service account creds later.