### PR TITLE
Bump relations-api, Nimbus oauth2-oidc-sdk and Protobuf protobuf versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,17 +56,17 @@
     <dependency>
       <groupId>org.project-kessel</groupId>
       <artifactId>relations-client-java</artifactId>
-      <version>0.9</version>
+      <version>0.12</version>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>oauth2-oidc-sdk</artifactId>
-      <version>11.13</version>
+      <version>11.24</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.25.5</version>
+      <version>3.25.7</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Bump some versions of dependencies that should be safe.
(No CVE vulnerabilities found.)